### PR TITLE
Update runtime

### DIFF
--- a/com.ylsoftware.qmmp.Qmmp.yml
+++ b/com.ylsoftware.qmmp.Qmmp.yml
@@ -78,13 +78,13 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
-        sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
+        url: https://github.com/libgme/game-music-emu/archive/refs/tags/0.6.3.tar.gz
+        sha256: 4c5a7614acaea44e5cb1423817d2889deb82674ddbc4e3e1291614304b86fca0
         x-checker-data:
           type: anitya
           project-id: 866
           stable-only: true
-          url-template: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-$version.tar.xz
+          url-template: https://github.com/libgme/game-music-emu/archive/refs/tags/$version.tar.gz
 
   - name: wildmidi
     buildsystem: cmake-ninja

--- a/com.ylsoftware.qmmp.Qmmp.yml
+++ b/com.ylsoftware.qmmp.Qmmp.yml
@@ -1,6 +1,6 @@
 app-id: com.ylsoftware.qmmp.Qmmp
 runtime: org.kde.Platform
-runtime-version: 6.5
+runtime-version: 6.6
 sdk: org.kde.Sdk
 command: qmmp
 rename-icon: qmmp


### PR DESCRIPTION
### runtime: Update runtime version

Update out-of-date runtime version to 6.6

### module: update game-music-emu

The bitbucket page of game-music-emu seem out-of-date and redirects to game-music-emu on github.